### PR TITLE
revert: removed semantic-release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,30 +4,11 @@
 name: Node.js Package
 
 on:
-  push:
-    branches:
-     - main
+  release:
+    types: [created]
 
 jobs:
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js v14
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14
-    - run: yarn install --frozen-lockfile
-    - run: yarn test
-    - name: Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: unittests
-
   publish-npm:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -37,15 +18,11 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: yarn build
-
-      - name: Release new version to NPM
+      - run: yarn publish --access public
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
 
   publish-gpr:
-    needs: [build, publish-npm]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Invalid npm token, and sometimes don't need to publish when merged into main branch.